### PR TITLE
Fix gzip-compressed 3D model downloads

### DIFF
--- a/src/kicad_jlcimport/easyeda/api.py
+++ b/src/kicad_jlcimport/easyeda/api.py
@@ -1,5 +1,6 @@
 """EasyEDA/LCSC HTTP client using only urllib."""
 
+import gzip
 import json
 import logging
 import os
@@ -441,7 +442,10 @@ def download_step(uuid_3d: str) -> Optional[bytes]:
     req = urllib.request.Request(url, headers=_HEADERS)
     try:
         with _urlopen(req, timeout=60) as resp:
-            return resp.read()
+            data = resp.read()
+            if data[:2] == b"\x1f\x8b":
+                data = gzip.decompress(data)
+            return data
     except (urllib.error.HTTPError, urllib.error.URLError):
         return None
 
@@ -452,7 +456,10 @@ def download_wrl_source(uuid_3d: str) -> Optional[str]:
     req = urllib.request.Request(url, headers=_HEADERS)
     try:
         with _urlopen(req, timeout=60) as resp:
-            return resp.read().decode("utf-8")
+            data = resp.read()
+            if data[:2] == b"\x1f\x8b":
+                data = gzip.decompress(data)
+            return data.decode("utf-8")
     except (urllib.error.HTTPError, urllib.error.URLError):
         return None
 


### PR DESCRIPTION
## Summary
- The EasyEDA 3D model API sometimes returns gzip-compressed responses
- `download_wrl_source` crashed with `UnicodeDecodeError` when trying to decode compressed bytes as UTF-8
- Both `download_step` and `download_wrl_source` now detect gzip magic bytes (`1f 8b`) and decompress before processing

## Test plan
- [ ] Import a component with a 3D model (e.g. C123947 / SS56) and verify no decode error
- [ ] Verify STEP and WRL files are correctly saved