### PR TITLE
Publish visual comparison to GitHub Pages on release

### DIFF
--- a/.github/workflows/visual-comparison.yml
+++ b/.github/workflows/visual-comparison.yml
@@ -1,0 +1,57 @@
+name: Visual Comparison
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  pages: write
+  id-token: write
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install KiCad
+        run: |
+          sudo add-apt-repository --yes ppa:kicad/kicad-9.0-releases
+          sudo apt-get update
+          sudo apt-get install -y kicad
+
+      - name: Install project
+        run: pip install -e .
+
+      - name: Run visual comparison
+        run: |
+          python tools/compare_part.py \
+            C82899 C7593 C5213 C5423 C7950 C9418 C33696 C71101 C6970 C21235 \
+            C23892 C6186 C6187 C6188 C12087 C14529 C347218 C347219 C3794 C5586 \
+            C5206 C5602 C8760 C8852 C13885 C15157 C18901 C20953 C10081 C94598 \
+            C94599 C138392 C385834 C386756 C386757 C386758 C52016391 C5177 C15134 C24112 \
+            C2957 C2960 C67528 C85181 C2102 C2135 C2474 C2476 C2478 C2479 \
+            C173573 C173580 C173602 C1027 C1034 C2286 C2288 C2290 C2295 C2297 \
+            C12889 C15331 C2078 C2560 C2561 C2562 C2564 C2566 C2079 C2173 \
+            C2914 C3795 C3797 C2040 C2316 C2318 C2319 C2320 C2321 C2322 \
+            C2202 C2203 C2213 C3099 C3105 C3116 C3117 C5419 C5612 C5613 \
+            C6203 C6205 C7519 C15999 C6179 C6855 C6912 C7063 C1002 C1035 \
+            --output-dir ./pages --no-open
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./pages
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ The plugin automatically creates and updates `sym-lib-table` and `fp-lib-table` 
 
 For a detailed look at the architecture, data flow, module responsibilities, and external APIs, see the [Architecture Documentation](docs/architecture.md).
 
+A [visual comparison](https://jvanderberg.github.io/kicad_jlcimport/) of EasyEDA source renderings vs KiCad conversion output is published on each release, covering 100 parts across ICs, passives, LEDs, transistors, and connectors.
+
 ## Requirements
 
 - KiCad 8.0+


### PR DESCRIPTION
## Summary
- Auto-detect `kicad-cli` via `shutil.which()` with macOS fallback, so `compare_part.py` works on Linux CI
- Add `--output-dir` flag to write HTML to a specified directory (as `index.html`) instead of a temp dir
- New `visual-comparison.yml` workflow runs the 100-part comparison on `v*` tags and deploys the result to GitHub Pages
- Link the published comparison page from the README

## Test plan
- [ ] Run `python3 tools/compare_part.py C2040 --output-dir /tmp/pages --no-open` locally and verify `index.html` appears in `/tmp/pages/`
- [ ] Verify `ruff check .`, `ruff format --check .`, and `pytest` all pass
- [ ] After merge, tag a release and confirm the workflow runs and the page is published at https://jvanderberg.github.io/kicad_jlcimport/