### PR TITLE
Add multi-unit symbol import support for components

### DIFF
--- a/src/kicad_jlcimport/importer.py
+++ b/src/kicad_jlcimport/importer.py
@@ -170,28 +170,44 @@ def import_component(
             footprint.model, comp["fp_origin_x"], comp["fp_origin_y"], wrl_source
         )
 
-    # Parse symbol
+    # Parse symbol (may have multiple units)
     sym_content = ""
     if comp["symbol_data_list"]:
         log("Parsing symbol...")
-        sym_data = comp["symbol_data_list"][0]
-        sym_shapes = sym_data["dataStr"]["shape"]
-        symbol = parse_symbol_shapes(sym_shapes, comp["sym_origin_x"], comp["sym_origin_y"])
-        log(f"  {len(symbol.pins)} pins, {len(symbol.rectangles)} rects")
-
+        total_units = len(comp["symbol_data_list"])
         footprint_ref = f"{lib_name}:{name}"
-        sym_content = write_symbol(
-            symbol,
-            name,
-            prefix=comp["prefix"],
-            footprint_ref=footprint_ref,
-            lcsc_id=lcsc_id,
-            datasheet=comp.get("datasheet", ""),
-            description=metadata["description"],
-            keywords=metadata["keywords"],
-            manufacturer=metadata["manufacturer"],
-            manufacturer_part=comp.get("manufacturer_part", ""),
-        )
+        sym_parts = []
+        total_pins = 0
+        total_rects = 0
+
+        for unit_idx, sym_data in enumerate(comp["symbol_data_list"]):
+            # Each unit may have its own origin
+            origin_x = sym_data.get("dataStr", {}).get("head", {}).get("x", comp["sym_origin_x"])
+            origin_y = sym_data.get("dataStr", {}).get("head", {}).get("y", comp["sym_origin_y"])
+            sym_shapes = sym_data["dataStr"]["shape"]
+            symbol = parse_symbol_shapes(sym_shapes, origin_x, origin_y)
+            total_pins += len(symbol.pins)
+            total_rects += len(symbol.rectangles)
+
+            sym_parts.append(
+                write_symbol(
+                    symbol,
+                    name,
+                    prefix=comp["prefix"],
+                    footprint_ref=footprint_ref,
+                    lcsc_id=lcsc_id,
+                    datasheet=comp.get("datasheet", ""),
+                    description=metadata["description"],
+                    keywords=metadata["keywords"],
+                    manufacturer=metadata["manufacturer"],
+                    manufacturer_part=comp.get("manufacturer_part", ""),
+                    unit_index=unit_idx,
+                    total_units=total_units,
+                )
+            )
+
+        sym_content = "".join(sym_parts)
+        log(f"  {total_pins} pins, {total_rects} rects ({total_units} unit(s))")
     else:
         log("No symbol data available")
 

--- a/src/kicad_jlcimport/kicad/symbol_writer.py
+++ b/src/kicad_jlcimport/kicad/symbol_writer.py
@@ -224,7 +224,7 @@ def write_symbol(
 
     lines.append("    )")  # Close unit sub-symbol
 
-    if unit_index == 0 or (unit_index == total_units - 1 and total_units > 1):
+    if total_units <= 1 or unit_index == total_units - 1:
         lines.append("  )")  # Close outer symbol
 
     return "\n".join(lines) + "\n"

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -400,6 +400,146 @@ class TestImportComponent:
         assert "${KIPRJMOD}" not in captured_model_path[0]
 
 
+class TestMultiUnitSymbolImport:
+    """Tests for multi-unit symbol import."""
+
+    def _make_fake_comp(self, num_units=2):
+        """Create a fake component with multiple symbol units."""
+        symbol_data_list = []
+        for i in range(num_units):
+            symbol_data_list.append(
+                {
+                    "dataStr": {
+                        "head": {"x": i * 100, "y": i * 100},
+                        "shape": [],
+                    }
+                }
+            )
+        return {
+            "title": "DualMOSFET",
+            "prefix": "Q",
+            "description": "Dual N-Channel MOSFET",
+            "datasheet": "https://example.com/ds.pdf",
+            "manufacturer": "ACME",
+            "manufacturer_part": "DUAL-MOS",
+            "footprint_data": {"dataStr": {"shape": []}},
+            "fp_origin_x": 0,
+            "fp_origin_y": 0,
+            "symbol_data_list": symbol_data_list,
+            "sym_origin_x": 0,
+            "sym_origin_y": 0,
+        }
+
+    def _make_fake_footprint(self):
+        fp = EEFootprint()
+        pad = EEPad(shape="RECT", x=0, y=0, width=1, height=1, layer="1", number="1", drill=0, rotation=0)
+        fp.pads.append(pad)
+        return fp
+
+    def test_multi_unit_calls_write_symbol_per_unit(self, tmp_path, monkeypatch):
+        """write_symbol should be called once per symbol unit with correct indices."""
+        fake_comp = self._make_fake_comp(num_units=3)
+        fake_fp = self._make_fake_footprint()
+        fake_sym = EESymbol()
+        fake_sym.pins.append(EEPin(number="1", name="G", x=0, y=0, rotation=0, length=2.54, electrical_type="input"))
+
+        write_calls = []
+
+        def capture_write_symbol(*args, **kwargs):
+            write_calls.append(kwargs)
+            return '    (symbol "DualMOSFET_0_1")\n'
+
+        monkeypatch.setattr(importer, "fetch_full_component", lambda _: fake_comp)
+        monkeypatch.setattr(importer, "parse_footprint_shapes", lambda *a, **k: fake_fp)
+        monkeypatch.setattr(importer, "parse_symbol_shapes", lambda *a, **k: fake_sym)
+        monkeypatch.setattr(importer, "write_footprint", lambda *a, **k: "(footprint DualMOSFET)\n")
+        monkeypatch.setattr(importer, "write_symbol", capture_write_symbol)
+
+        importer.import_component(
+            "C42372676",
+            str(tmp_path),
+            "TestLib",
+            export_only=True,
+            log=lambda msg: None,
+        )
+
+        assert len(write_calls) == 3
+        assert write_calls[0]["unit_index"] == 0
+        assert write_calls[0]["total_units"] == 3
+        assert write_calls[1]["unit_index"] == 1
+        assert write_calls[1]["total_units"] == 3
+        assert write_calls[2]["unit_index"] == 2
+        assert write_calls[2]["total_units"] == 3
+
+    def test_multi_unit_uses_per_unit_origin(self, tmp_path, monkeypatch):
+        """Each symbol unit should use its own origin from dataStr.head."""
+        fake_comp = self._make_fake_comp(num_units=2)
+        # Set distinct origins for each unit
+        fake_comp["symbol_data_list"][0]["dataStr"]["head"]["x"] = 100
+        fake_comp["symbol_data_list"][0]["dataStr"]["head"]["y"] = 200
+        fake_comp["symbol_data_list"][1]["dataStr"]["head"]["x"] = 300
+        fake_comp["symbol_data_list"][1]["dataStr"]["head"]["y"] = 400
+
+        parse_calls = []
+
+        def capture_parse(shapes, ox, oy):
+            parse_calls.append((ox, oy))
+            return EESymbol()
+
+        fake_fp = self._make_fake_footprint()
+
+        monkeypatch.setattr(importer, "fetch_full_component", lambda _: fake_comp)
+        monkeypatch.setattr(importer, "parse_footprint_shapes", lambda *a, **k: fake_fp)
+        monkeypatch.setattr(importer, "parse_symbol_shapes", capture_parse)
+        monkeypatch.setattr(importer, "write_footprint", lambda *a, **k: "(footprint DualMOSFET)\n")
+        monkeypatch.setattr(importer, "write_symbol", lambda *a, **k: '    (symbol "X_0_1")\n')
+
+        importer.import_component(
+            "C42372676",
+            str(tmp_path),
+            "TestLib",
+            export_only=True,
+            log=lambda msg: None,
+        )
+
+        assert len(parse_calls) == 2
+        assert parse_calls[0] == (100, 200)
+        assert parse_calls[1] == (300, 400)
+
+    def test_single_unit_backward_compatible(self, tmp_path, monkeypatch):
+        """Single-unit components should still work as before."""
+        fake_comp = self._make_fake_comp(num_units=1)
+        fake_fp = self._make_fake_footprint()
+        fake_sym = EESymbol()
+        fake_sym.pins.append(
+            EEPin(number="1", name="VCC", x=0, y=0, rotation=0, length=2.54, electrical_type="power_in")
+        )
+
+        write_calls = []
+
+        def capture_write_symbol(*args, **kwargs):
+            write_calls.append(kwargs)
+            return '  (symbol "Test")\n'
+
+        monkeypatch.setattr(importer, "fetch_full_component", lambda _: fake_comp)
+        monkeypatch.setattr(importer, "parse_footprint_shapes", lambda *a, **k: fake_fp)
+        monkeypatch.setattr(importer, "parse_symbol_shapes", lambda *a, **k: fake_sym)
+        monkeypatch.setattr(importer, "write_footprint", lambda *a, **k: "(footprint Test)\n")
+        monkeypatch.setattr(importer, "write_symbol", capture_write_symbol)
+
+        importer.import_component(
+            "C123",
+            str(tmp_path),
+            "TestLib",
+            export_only=True,
+            log=lambda msg: None,
+        )
+
+        assert len(write_calls) == 1
+        assert write_calls[0]["unit_index"] == 0
+        assert write_calls[0]["total_units"] == 1
+
+
 class TestImportBackslashPaths:
     """Tests for backslash path handling in importer."""
 

--- a/tests/test_symbol_writer.py
+++ b/tests/test_symbol_writer.py
@@ -193,6 +193,60 @@ class TestWriteSymbol:
         # Single unit: uses _0_1
         assert '(symbol "MyPart_0_1"' in result
 
+    def test_multi_unit_first_unit_does_not_close_outer(self):
+        """For multi-unit symbols, the first unit must NOT close the outer symbol wrapper."""
+        sym = _make_symbol(
+            pins=[EEPin(number="1", name="A", x=0, y=0, rotation=0, length=2.54, electrical_type="input")]
+        )
+        result = write_symbol(sym, "DualMOS", unit_index=0, total_units=2)
+        # Should have outer symbol opening
+        assert '(symbol "DualMOS"' in result
+        # Should have unit sub-symbol with unit number 0
+        assert '(symbol "DualMOS_0_1"' in result
+        # Count closing parens at the top level: the outer symbol should NOT be closed
+        # The result should end with just the unit sub-symbol closing
+        lines = result.strip().split("\n")
+        # Should NOT have a final "  )" closing the outer symbol
+        assert lines[-1].strip() == ")", "First unit should close sub-symbol but not outer"
+        # Check there's no double-close at the end
+        assert lines[-1] != "  )", "First unit of multi-unit must not close outer symbol"
+
+    def test_multi_unit_last_unit_closes_outer(self):
+        """For multi-unit symbols, the last unit should close the outer symbol wrapper."""
+        sym = _make_symbol(
+            pins=[EEPin(number="2", name="B", x=0, y=0, rotation=0, length=2.54, electrical_type="input")]
+        )
+        result = write_symbol(sym, "DualMOS", unit_index=1, total_units=2)
+        # Should have unit sub-symbol with unit number 1
+        assert '(symbol "DualMOS_1_1"' in result
+        # Last two lines should close sub-symbol and outer symbol
+        lines = result.strip().split("\n")
+        assert lines[-1].strip() == ")"
+        assert lines[-2].strip() == ")"
+
+    def test_multi_unit_concatenation_produces_valid_structure(self):
+        """Concatenating all units should produce a valid symbol with multiple sub-symbols."""
+        sym1 = _make_symbol(
+            pins=[EEPin(number="1", name="A", x=0, y=0, rotation=0, length=2.54, electrical_type="input")]
+        )
+        sym2 = _make_symbol(
+            pins=[EEPin(number="2", name="B", x=0, y=5, rotation=0, length=2.54, electrical_type="output")]
+        )
+        part1 = write_symbol(sym1, "DualPart", prefix="U", unit_index=0, total_units=2)
+        part2 = write_symbol(sym2, "DualPart", unit_index=1, total_units=2)
+        full = part1 + part2
+
+        # Both sub-symbols should be present
+        assert '(symbol "DualPart_0_1"' in full
+        assert '(symbol "DualPart_1_1"' in full
+        # Outer wrapper should appear once
+        assert full.count('(symbol "DualPart"') == 1
+        # Properties should appear in first unit only
+        assert full.count('(property "Reference"') == 1
+        # Both pins should be present
+        assert '(name "A"' in full
+        assert '(name "B"' in full
+
     def test_rounded_rect_produces_closed_polyline(self):
         """A rounded rectangle must produce a closed polyline (first point == last point).
 


### PR DESCRIPTION
## Summary
This PR adds support for importing components with multiple symbol units (e.g., dual MOSFETs, quad op-amps). Previously, only the first symbol unit was imported. Now the importer processes all units and generates properly structured multi-unit symbols in KiCad format.

## Key Changes

- **Multi-unit symbol parsing**: Modified `import_component()` to iterate through all units in `symbol_data_list` instead of just the first one
- **Per-unit origin support**: Each symbol unit can now have its own origin coordinates from `dataStr.head`, allowing proper positioning of multi-unit components
- **Symbol writer updates**: Fixed `write_symbol()` logic to:
  - Accept `unit_index` and `total_units` parameters
  - Only close the outer symbol wrapper on the last unit (not the first)
  - Properly concatenate multiple unit definitions into a single valid KiCad symbol
- **Backward compatibility**: Single-unit components continue to work as before with `unit_index=0` and `total_units=1`

## Implementation Details

- Symbol units are processed sequentially, with each unit's shapes parsed using its own origin coordinates
- The outer symbol wrapper (properties, reference, value) is written only once with the first unit
- Subsequent units only contain their sub-symbol definitions
- The final unit closes both the sub-symbol and outer wrapper
- Comprehensive test coverage added for multi-unit scenarios, per-unit origins, and backward compatibility

https://claude.ai/code/session_013qLQkT7KV2Bc7XtMRjKZD6