### PR TITLE
Fix Python 3.9 annotation evaluation error

### DIFF
--- a/src/kicad_jlcimport/kicad/library.py
+++ b/src/kicad_jlcimport/kicad/library.py
@@ -1,5 +1,7 @@
 """Library file management - create/append symbols, save footprints, update lib-tables."""
 
+from __future__ import annotations
+
 import json
 import os
 import re


### PR DESCRIPTION
Python 3.9 failed during test collection because of runtime evaluation of str | None annotations in src/kicad_jlcimport/kicad/library.py.

This adds from __future__ import annotations to defer annotation evaluation and restore 3.9 compatibility.