### PR TITLE
fix: defer ssl import and add curl fallback for AppImage compatibility

### DIFF
--- a/src/kicad_jlcimport/easyeda/api.py
+++ b/src/kicad_jlcimport/easyeda/api.py
@@ -383,6 +383,8 @@ def _get_json(url: str) -> Any:
     try:
         with _urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read().decode("utf-8"))
+    except APIError:
+        raise  # curl fallback already wraps errors as APIError
     except urllib.error.HTTPError as e:
         raise APIError(f"HTTP {e.code} fetching {url}") from e
     except urllib.error.URLError as e:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -622,6 +622,12 @@ class TestGetJson:
             with pytest.raises(APIError, match="Network error"):
                 api._get_json("https://example.com/api")
 
+    def test_api_error_passthrough(self):
+        """APIError from curl fallback propagates without being re-wrapped."""
+        with mock.patch.object(api, "_urlopen", side_effect=APIError("HTTP 502 fetching url")):
+            with pytest.raises(APIError, match="HTTP 502"):
+                api._get_json("https://example.com/api")
+
 
 class TestFetchComponentUuids:
     def test_success(self):

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -15,10 +15,11 @@ class TestMakeSslContext:
     """Tests for _make_ssl_context."""
 
     def test_creates_verified_context(self):
-        # The function is called at module import; verify the global is usable
-        assert api._SSL_CTX is not None
-        assert api._SSL_CTX.check_hostname is True
-        assert api._SSL_CTX.verify_mode == ssl.CERT_REQUIRED
+        # SSL context is lazily initialized; trigger it via _get_ssl_ctx()
+        ctx = api._get_ssl_ctx()
+        assert ctx is not None
+        assert ctx.check_hostname is True
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
 
     def test_prefers_bundled_cacerts(self, monkeypatch, tmp_path):
         """When cacerts.pem exists and is valid, it should be used."""
@@ -36,11 +37,30 @@ class TestMakeSslContext:
         assert ctx is not None
         assert ctx.check_hostname is True
 
-    def test_falls_back_to_certifi(self, monkeypatch):
+    def test_falls_back_to_certifi(self, monkeypatch, tmp_path):
         """When no cacerts.pem exists, certifi should be tried."""
+        import os
+
         monkeypatch.setattr(api, "_CACERTS_PEM", "/nonexistent/cacerts.pem")
+
+        # certifi may not be installed; provide a fake module using the project's real CA bundle
+        project_pem = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "src", "kicad_jlcimport", "easyeda", "cacerts.pem"
+        )
+        fake_certifi = MagicMock()
+        fake_certifi.where.return_value = project_pem
+
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "certifi":
+                return fake_certifi
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
         ctx = api._make_ssl_context()
-        # certifi is installed in the test environment, so this should succeed
         assert ctx is not None
         assert ctx.verify_mode == ssl.CERT_REQUIRED
 
@@ -63,6 +83,31 @@ class TestMakeSslContext:
 
         ctx = api._make_ssl_context()
         assert ctx is None
+
+    def test_certifi_load_failure_falls_through(self, monkeypatch, tmp_path):
+        """When certifi is importable but load_verify_locations fails, fall through to system store."""
+        monkeypatch.setattr(api, "_CACERTS_PEM", "/nonexistent/cacerts.pem")
+
+        # Create a file with invalid cert content so load_verify_locations fails
+        bad_pem = tmp_path / "bad_certifi.pem"
+        bad_pem.write_text("this is not a valid certificate")
+
+        fake_certifi = MagicMock()
+        fake_certifi.where.return_value = str(bad_pem)
+
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "certifi":
+                return fake_certifi
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
+        # System store fallback should still work
+        ctx = api._make_ssl_context()
+        assert ctx is not None
 
 
 class TestUrlopen:


### PR DESCRIPTION
## Problem

The KiCad 10 AppImage bundles `libcrypto.so.3` which can be incompatible with
the host system's `libssl.so.3`. On systems where the host requires
`OPENSSL_3.3.0` (e.g. Ubuntu 24.04+), Python's `import ssl` fails with:

```
ImportError: .../libcrypto.so.3: version 'OPENSSL_3.3.0' not found
(required by /usr/lib/x86_64-linux-gnu/libssl.so.3)
```

This crashes the entire plugin import chain because `api.py` imports `ssl` at
module level. Since `__init__.py` catches `ImportError` silently, the plugin
simply never appears in KiCad — with no error message shown to the user.

## Root Cause

`api.py` has `import ssl` at the top level and calls `_make_ssl_context()` at
module load time (`_SSL_CTX = _make_ssl_context()`). The import chain
`plugin.py → dialog.py → api.py → import ssl` fails before the plugin can
register itself.

## Fix

1. **Defer `import ssl`** — moved from module level to inside `_make_ssl_context()`
   and `_urlopen()`, so plugin registration succeeds even when ssl is broken.

2. **Lazy-initialize `_SSL_CTX`** — created on first network request instead of
   at import time, guarded by `_check_ssl_available()`.

3. **Add curl subprocess fallback** — when `ssl` is entirely unavailable,
   `_urlopen()` routes HTTPS requests through the system `curl` binary. This
   keeps the plugin fully functional.

## Testing

Tested with KiCad 10.0.0 AppImage on Ubuntu where the OpenSSL mismatch occurs:

- Plugin registers and appears in KiCad toolbar ✓
- `_check_ssl_available()` correctly returns `False` ✓
- curl fallback activates automatically ✓
- API calls (search, fetch component, fetch UUIDs) all succeed via curl ✓
- No behavior change on systems where ssl works normally ✓

## Changes

- `src/kicad_jlcimport/easyeda/api.py`: 1 file, +131 −4 lines