### PR TITLE
Fix global library registration and 3D model paths

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   },
   "versions": [
     {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "status": "stable",
       "kicad_version": "8.0",
       "runtime": "swig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kicad-jlcimport"
-version = "1.6.2"
+version = "1.6.3"
 description = "KiCad 8/9/10 plugin to import components from JLCPCB/LCSC"
 requires-python = ">=3.8"
 license = {text = "MIT"}

--- a/src/kicad_jlcimport/importer.py
+++ b/src/kicad_jlcimport/importer.py
@@ -10,6 +10,7 @@ from .easyeda.parser import parse_footprint_shapes, parse_symbol_shapes
 from .kicad.footprint_writer import write_footprint
 from .kicad.library import (
     add_symbol_to_lib,
+    default_global_lib_dir,
     ensure_lib_structure,
     find_best_matching_footprint,
     sanitize_name,
@@ -81,6 +82,19 @@ def _check_existing_files(
     if os.path.exists(step_path) or os.path.exists(wrl_path):
         existing.append("3D model")
     return existing
+
+
+def _global_model_path(lib_dir: str, lib_name: str, model_name: str, kicad_version: int) -> str:
+    """Build the 3D model path for a global library import.
+
+    Uses the ``${KICADxx_3RD_PARTY}`` variable when the library lives in the
+    default 3rd-party directory, otherwise falls back to an absolute path so
+    custom directories (e.g. ~/Downloads) resolve correctly.
+    """
+    default_dir = default_global_lib_dir(kicad_version)
+    if os.path.normpath(lib_dir) == os.path.normpath(default_dir):
+        return f"${{KICAD{kicad_version}_3RD_PARTY}}/{lib_name}.3dshapes/{model_name}.wrl"
+    return os.path.join(lib_dir, f"{lib_name}.3dshapes", f"{model_name}.wrl").replace("\\", "/")
 
 
 def import_component(
@@ -494,7 +508,7 @@ def _import_to_library(
         # Use WRL instead of STEP for consistency with offset calculations (which use OBJ/WRL geometry)
         if wrl_path:
             if use_global:
-                model_path = f"${{KICAD{kicad_version}_3RD_PARTY}}/{lib_name}.3dshapes/{model_name}.wrl"
+                model_path = _global_model_path(lib_dir, lib_name, model_name, kicad_version)
             else:
                 model_path = f"${{KIPRJMOD}}/{lib_name}.3dshapes/{model_name}.wrl"
             if wrl_existed and not overwrite:

--- a/src/kicad_jlcimport/importer.py
+++ b/src/kicad_jlcimport/importer.py
@@ -9,8 +9,8 @@ from .easyeda.api import download_step, download_wrl_source, fetch_full_componen
 from .easyeda.parser import parse_footprint_shapes, parse_symbol_shapes
 from .kicad.footprint_writer import write_footprint
 from .kicad.library import (
+    _default_3rdparty_dir,
     add_symbol_to_lib,
-    default_global_lib_dir,
     ensure_lib_structure,
     find_best_matching_footprint,
     sanitize_name,
@@ -91,7 +91,7 @@ def _global_model_path(lib_dir: str, lib_name: str, model_name: str, kicad_versi
     default 3rd-party directory, otherwise falls back to an absolute path so
     custom directories (e.g. ~/Downloads) resolve correctly.
     """
-    default_dir = default_global_lib_dir(kicad_version)
+    default_dir = _default_3rdparty_dir(kicad_version)
     if os.path.normpath(lib_dir) == os.path.normpath(default_dir):
         return f"${{KICAD{kicad_version}_3RD_PARTY}}/{lib_name}.3dshapes/{model_name}.wrl"
     return os.path.join(lib_dir, f"{lib_name}.3dshapes", f"{model_name}.wrl").replace("\\", "/")

--- a/src/kicad_jlcimport/kicad/library.py
+++ b/src/kicad_jlcimport/kicad/library.py
@@ -243,11 +243,10 @@ def get_global_lib_dir(kicad_version: int = DEFAULT_KICAD_VERSION) -> str:
         if not os.path.isdir(custom):
             raise ValueError(f"Custom global library directory does not exist: {custom}")
         return custom
-    ver = version_dir_name(kicad_version)
-    return os.path.join(_kicad_data_base(), ver, "3rdparty")
+    return _default_3rdparty_dir(kicad_version)
 
 
-def default_global_lib_dir(kicad_version: int = DEFAULT_KICAD_VERSION) -> str:
+def _default_3rdparty_dir(kicad_version: int = DEFAULT_KICAD_VERSION) -> str:
     """Return the default 3rd-party library directory (ignoring any custom override)."""
     ver = version_dir_name(kicad_version)
     return os.path.join(_kicad_data_base(), ver, "3rdparty")
@@ -272,36 +271,6 @@ def update_global_lib_tables(
 
     _update_lib_table(os.path.join(config_dir, "sym-lib-table"), "sym_lib_table", lib_name, "KiCad", sym_uri)
     _update_lib_table(os.path.join(config_dir, "fp-lib-table"), "fp_lib_table", lib_name, "KiCad", fp_uri)
-
-    # When running inside KiCad, also register in pcbnew's in-memory table.
-    # KiCad keeps its own copy of the global fp-lib-table and overwrites the
-    # on-disk file when saving, so file-only writes get clobbered.
-    _register_fp_lib_in_pcbnew(lib_name, fp_uri)
-
-
-def _register_fp_lib_in_pcbnew(lib_name: str, fp_uri: str) -> bool:
-    """Register a footprint library in pcbnew's in-memory global table.
-
-    When running inside KiCad as a plugin, pcbnew holds the authoritative
-    copy of the global fp-lib-table.  Adding the library here ensures KiCad
-    sees it immediately and persists it when it next saves the table.
-
-    Returns True if the library was registered (or already present).
-    Returns False if pcbnew is not available (e.g. running from the TUI).
-    """
-    try:
-        import pcbnew
-
-        table = pcbnew.FP_LIB_TABLE.GetGlobalLibTable()
-        if table.HasLibrary(lib_name):
-            return True
-        row = pcbnew.FP_LIB_TABLE_ROW(lib_name, fp_uri, "KiCad", "", "")
-        table.InsertRow(row)
-        return True
-    except Exception:
-        # pcbnew not available (TUI / CLI) or API mismatch — fall back to
-        # the on-disk write that already happened above.
-        return False
 
 
 def _update_lib_table(table_path: str, table_type: str, lib_name: str, lib_type: str, uri: str) -> bool:

--- a/src/kicad_jlcimport/kicad/library.py
+++ b/src/kicad_jlcimport/kicad/library.py
@@ -247,6 +247,12 @@ def get_global_lib_dir(kicad_version: int = DEFAULT_KICAD_VERSION) -> str:
     return os.path.join(_kicad_data_base(), ver, "3rdparty")
 
 
+def default_global_lib_dir(kicad_version: int = DEFAULT_KICAD_VERSION) -> str:
+    """Return the default 3rd-party library directory (ignoring any custom override)."""
+    ver = version_dir_name(kicad_version)
+    return os.path.join(_kicad_data_base(), ver, "3rdparty")
+
+
 def get_global_config_dir(kicad_version: int = DEFAULT_KICAD_VERSION) -> str:
     """Get the global KiCad config directory (where global lib-tables live)."""
     ver = version_dir_name(kicad_version)
@@ -266,6 +272,36 @@ def update_global_lib_tables(
 
     _update_lib_table(os.path.join(config_dir, "sym-lib-table"), "sym_lib_table", lib_name, "KiCad", sym_uri)
     _update_lib_table(os.path.join(config_dir, "fp-lib-table"), "fp_lib_table", lib_name, "KiCad", fp_uri)
+
+    # When running inside KiCad, also register in pcbnew's in-memory table.
+    # KiCad keeps its own copy of the global fp-lib-table and overwrites the
+    # on-disk file when saving, so file-only writes get clobbered.
+    _register_fp_lib_in_pcbnew(lib_name, fp_uri)
+
+
+def _register_fp_lib_in_pcbnew(lib_name: str, fp_uri: str) -> bool:
+    """Register a footprint library in pcbnew's in-memory global table.
+
+    When running inside KiCad as a plugin, pcbnew holds the authoritative
+    copy of the global fp-lib-table.  Adding the library here ensures KiCad
+    sees it immediately and persists it when it next saves the table.
+
+    Returns True if the library was registered (or already present).
+    Returns False if pcbnew is not available (e.g. running from the TUI).
+    """
+    try:
+        import pcbnew
+
+        table = pcbnew.FP_LIB_TABLE.GetGlobalLibTable()
+        if table.HasLibrary(lib_name):
+            return True
+        row = pcbnew.FP_LIB_TABLE_ROW(lib_name, fp_uri, "KiCad", "", "")
+        table.InsertRow(row)
+        return True
+    except Exception:
+        # pcbnew not available (TUI / CLI) or API mismatch — fall back to
+        # the on-disk write that already happened above.
+        return False
 
 
 def _update_lib_table(table_path: str, table_type: str, lib_name: str, lib_type: str, uri: str) -> bool:


### PR DESCRIPTION
## Summary
- **3D model path fix**: Uses absolute paths for 3D models when the user selects a custom global library directory (e.g. `~/Downloads`). Previously, it always used `${KICAD10_3RD_PARTY}` which only resolves correctly for the default 3rd-party directory.
- **Deduplicate path logic**: Extract `_default_3rdparty_dir()` so `get_global_lib_dir()` and `_global_model_path()` share the same fallback path.

Note: Investigated using pcbnew's in-memory `FP_LIB_TABLE` API to prevent KiCad from clobbering on-disk lib-table entries, but KiCad 10 removed `FP_LIB_TABLE` from the SWIG bindings. The file-write approach is the only option.

Fixes #92

## Test plan
- [ ] Import a component using a custom global library directory (not the default 3rd-party path)
- [ ] Verify the 3D model loads correctly in the footprint editor (absolute path, not `${KICAD10_3RD_PARTY}`)
- [ ] Import using the default 3rd-party directory and confirm `${KICAD10_3RD_PARTY}` is still used

🤖 Generated with [Claude Code](https://claude.com/claude-code)