### PR TITLE
Construct LCSC URL fallback when JLCPCB API omits it

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ source install.sh      # macOS/Linux
 
 Based on recent git history:
 
+- `v1.6.5`: global search now falls back to a constructed `lcsc.com/product-detail/<code>.html` URL when the JLCPCB API omits `lcscGoodsUrl` (common for less-popular variants); skipped for `C99*` JLC-internal codes that don't have an LCSC.com listing.
 - `v1.6.4`: support for KiCad 10 `(type "Table")` fp-lib-table indirection (Linux/Windows fresh installs ship a chained default table) — footprint browser now resolves bundled libraries when they live behind a Table entry; cycle detection prevents loops on self-referential or circular table chains.
 - `v1.4.0`: KiCad footprint browser with live preview, footprint/3D model renaming, KiCad library footprint reuse, SpinnerOverlay deadlock fix, multi-unit symbol crash fix, and pinned ruff version.
 - `v1.2.10`: fixed Python 3.9 annotation evaluation in library handling.

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   },
   "versions": [
     {
-      "version": "1.6.4",
+      "version": "1.6.5",
       "status": "stable",
       "kicad_version": "8.0",
       "runtime": "swig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kicad-jlcimport"
-version = "1.6.4"
+version = "1.6.5"
 description = "KiCad 8/9/10 plugin to import components from JLCPCB/LCSC"
 requires-python = ">=3.8"
 license = {text = "MIT"}

--- a/src/kicad_jlcimport/easyeda/api.py
+++ b/src/kicad_jlcimport/easyeda/api.py
@@ -465,9 +465,13 @@ def search_components(
     for item in items:
         prices = item.get("componentPrices", [])
         unit_price = prices[0]["productPrice"] if prices else None
+        lcsc_code = item.get("componentCode", "")
+        url = item.get("lcscGoodsUrl") or ""
+        if not url and lcsc_code and not lcsc_code.startswith("C99"):
+            url = f"https://www.lcsc.com/product-detail/{lcsc_code}.html"
         results.append(
             {
-                "lcsc": item.get("componentCode", ""),
+                "lcsc": lcsc_code,
                 "name": item.get("componentName", ""),
                 "model": item.get("componentModelEn", ""),
                 "brand": item.get("componentBrandEn", ""),
@@ -477,7 +481,7 @@ def search_components(
                 "type": "Basic" if item.get("componentLibraryType") == "base" else "Extended",
                 "price": unit_price,
                 "description": item.get("describe", ""),
-                "url": item.get("lcscGoodsUrl", ""),
+                "url": url,
                 "datasheet": item.get("dataManualUrl", ""),
             }
         )

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -310,6 +310,93 @@ class TestSearchComponents:
             assert result["results"][0]["type"] == "Extended"
             assert result["results"][0]["price"] is None
 
+    def test_search_components_url_fallback_constructed(self, monkeypatch):
+        """When the API omits lcscGoodsUrl for a regular C-code, build it from the code."""
+        mock_response = MagicMock()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.read.return_value = json.dumps(
+            {
+                "data": {
+                    "componentPageInfo": {
+                        "total": 1,
+                        "list": [
+                            {
+                                "componentCode": "C22467836",
+                                "componentName": "MCU",
+                                "componentLibraryType": "expand",
+                                "componentPrices": [],
+                                "lcscGoodsUrl": None,
+                                "dataManualUrl": None,
+                            }
+                        ],
+                    }
+                }
+            }
+        ).encode()
+
+        with patch.object(api, "_urlopen", return_value=mock_response):
+            result = api.search_components("mcu")
+            assert result["results"][0]["url"] == "https://www.lcsc.com/product-detail/C22467836.html"
+
+    def test_search_components_url_fallback_skipped_for_c99(self, monkeypatch):
+        """JLC-internal C99* codes have no LCSC.com listing; leave url empty."""
+        mock_response = MagicMock()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.read.return_value = json.dumps(
+            {
+                "data": {
+                    "componentPageInfo": {
+                        "total": 1,
+                        "list": [
+                            {
+                                "componentCode": "C9900177353",
+                                "componentName": "Internal part",
+                                "componentLibraryType": "expand",
+                                "componentPrices": [],
+                                "lcscGoodsUrl": None,
+                                "dataManualUrl": None,
+                            }
+                        ],
+                    }
+                }
+            }
+        ).encode()
+
+        with patch.object(api, "_urlopen", return_value=mock_response):
+            result = api.search_components("internal")
+            assert result["results"][0]["url"] == ""
+
+    def test_search_components_url_provided_is_preserved(self, monkeypatch):
+        """Don't overwrite a URL the API already returned."""
+        mock_response = MagicMock()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.read.return_value = json.dumps(
+            {
+                "data": {
+                    "componentPageInfo": {
+                        "total": 1,
+                        "list": [
+                            {
+                                "componentCode": "C22398291",
+                                "componentName": "MCU",
+                                "componentLibraryType": "expand",
+                                "componentPrices": [],
+                                "lcscGoodsUrl": "https://www.lcsc.com/product-detail/long-form_C22398291.html",
+                                "dataManualUrl": None,
+                            }
+                        ],
+                    }
+                }
+            }
+        ).encode()
+
+        with patch.object(api, "_urlopen", return_value=mock_response):
+            result = api.search_components("mcu")
+            assert result["results"][0]["url"] == "https://www.lcsc.com/product-detail/long-form_C22398291.html"
+
     def test_search_components_error(self, monkeypatch):
         def raise_error(*args, **kwargs):
             raise urllib.error.HTTPError("url", 500, "Server Error", {}, None)


### PR DESCRIPTION
## Summary
- The global search (JLCPCB API) often returns `null` for `lcscGoodsUrl` and `dataManualUrl` on less-popular variants. Reproduced with `CH32L103`: only the top-stock result (C22398291) had URLs; the other two visible rows (C22472334, C22467836) had none.
- When `lcscGoodsUrl` is missing, construct `https://www.lcsc.com/product-detail/<code>.html` — verified that LCSC serves this short form and returns it as the canonical URL.
- Skip the fallback for `C99*` codes (e.g. `C9900177353`), since those are JLC-internal parts with no LCSC.com listing — linking would land on a "Page Not Found" page.
- The China search (`search_components_cn`) is unaffected; it already self-constructs the szlcsc.com URL from `productId` and pulls the datasheet from a structured field, so all results show URLs there.
- Datasheet URL is left as-is — its filename embeds an opaque numeric ID we can't construct without an extra HTTP call per result.

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest` passes (824 tests, 92.25% coverage)
- [x] New tests cover: fallback constructed for regular code, fallback skipped for `C99*`, provided URL preserved
- [ ] Manual: search `CH32L103` in the global region in the dialog and confirm the LCSC link is populated for the 2nd and 3rd rows