### PR TITLE
Fix pin grid alignment for net-label connectivity (#100)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   },
   "versions": [
     {
-      "version": "1.6.5",
+      "version": "1.6.6",
       "status": "stable",
       "kicad_version": "8.0",
       "runtime": "swig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kicad-jlcimport"
-version = "1.6.5"
+version = "1.6.6"
 description = "KiCad 8/9/10 plugin to import components from JLCPCB/LCSC"
 requires-python = ">=3.8"
 license = {text = "MIT"}

--- a/src/kicad_jlcimport/easyeda/parser.py
+++ b/src/kicad_jlcimport/easyeda/parser.py
@@ -49,14 +49,17 @@ PIN_TYPES = {
 _SOLID_REGION_LAYERS = {"3", "4", "12"}
 
 
-# EasyEDA stores coordinates in 10-mil units (1 unit = 10 mils = 0.254 mm).
-# Dividing by 3.937 converts EasyEDA units to millimeters (3.937 ≈ 1/0.254).
-MILS_TO_MM_DIVISOR = 3.937
+# EasyEDA stores coordinates in 10-mil units (1 unit = 10 mils = 0.254 mm exactly).
+# Multiplying by 0.254 is the exact conversion; the previous divisor 3.937 was a
+# rounded approximation of 1/0.254 = 3.93700787... and pushed pin endpoints off
+# KiCad's internal nanometre grid by ~50–500 nm, breaking net-label auto-connect
+# (issue #100).
+MILS_TO_MM_MULTIPLIER = 0.254
 
 
 def mil_to_mm(mil: float) -> float:
     """Convert EasyEDA units (10-mil) to millimeters."""
-    return mil / MILS_TO_MM_DIVISOR
+    return mil * MILS_TO_MM_MULTIPLIER
 
 
 _SVG_ARC_RE = re.compile(

--- a/src/kicad_jlcimport/kicad/model3d.py
+++ b/src/kicad_jlcimport/kicad/model3d.py
@@ -18,20 +18,16 @@ import os
 from typing import Optional, Tuple
 
 from ..easyeda.ee_types import EE3DModel
+from ..easyeda.parser import mil_to_mm
 
 # ============================================================================
-# Unit Conversion Constants
+# Unit Conversion
 # ============================================================================
-
-# EasyEDA uses a coordinate system where 1 unit = 10 mils = 0.254mm
-# Conversion factor: 1 / 0.254 = 3.937 (to convert EasyEDA units to mm)
-# Note: 1 mil = 0.001 inch = 0.0254mm, so 10 mils = 0.254mm
-_EE_UNITS_TO_MM = 3.937
-
-# SVGNODE z field uses the same unit system (10 mils = 0.254mm per unit)
-# This was discovered by comparing EasyEDA UI values with raw data
-# Example: z=-13.7795 EasyEDA units = -13.7795 × 0.254mm = -3.5mm
-_Z_EE_UNITS_TO_MM = 3.937
+#
+# 3D model origin and SVGNODE z use the same 10-mil units as the rest of
+# EasyEDA's coordinate system, so they share the canonical mil_to_mm
+# conversion (1 unit = 10 mils = 0.254 mm exactly).
+# Example: z = -13.7795 EasyEDA units → -13.7795 × 0.254 mm = -3.5 mm.
 
 # ============================================================================
 # Spurious Offset Detection Thresholds
@@ -189,8 +185,8 @@ def compute_model_transform(
     cy_eff = cy if (height > 0 and abs(cy) / height > _SIGNIFICANT_CY_HEIGHT_RATIO) else 0.0
 
     # --- Effective origin diff: zero out spurious offsets (check both X and Y) ---
-    model_origin_diff_x = (model.origin_x - fp_origin_x) / _EE_UNITS_TO_MM
-    model_origin_diff_y = (model.origin_y - fp_origin_y) / _EE_UNITS_TO_MM
+    model_origin_diff_x = mil_to_mm(model.origin_x - fp_origin_x)
+    model_origin_diff_y = mil_to_mm(model.origin_y - fp_origin_y)
     # Use magnitude of offset vector to determine if spurious
     origin_diff_magnitude = (model_origin_diff_x**2 + model_origin_diff_y**2) ** 0.5
     is_spurious = _is_spurious_offset(origin_diff_magnitude, height)
@@ -198,7 +194,7 @@ def compute_model_transform(
     diff_eff_y = 0.0 if is_spurious else model_origin_diff_y
 
     # --- Z offset (universal formula) ---
-    z_offset = -z_min + (model.z / _Z_EE_UNITS_TO_MM)
+    z_offset = -z_min + mil_to_mm(model.z)
 
     # --- Geometry offset: rotates with the model ---
     # Only apply Z-axis rotation - X/Y rotations are handled by KiCad's model orientation

--- a/tests/test_model3d.py
+++ b/tests/test_model3d.py
@@ -36,7 +36,7 @@ class TestComputeModelTransform:
         # y' = -0.5*sin(90°) + (-0.5)*cos(90°) = -0.5*1 + (-0.5)*0 = -0.5
         assert offset[0] == pytest.approx(0.5)
         assert offset[1] == pytest.approx(-0.5)
-        # z_offset = -z_min + (model.z / 3.937) = -0 + (50 / 3.937) = 12.7mm
+        # z_offset = -z_min + mil_to_mm(model.z) = -0 + (50 × 0.254) = 12.7mm
         assert offset[2] == pytest.approx(12.7, abs=0.01)
         assert rotation == (0, 0, 90)
 
@@ -72,7 +72,7 @@ class TestComputeModelTransform:
         offset, _ = compute_model_transform(model, 0, 0, obj_source=obj)
         assert offset[0] == pytest.approx(-2.0)
         assert offset[1] == pytest.approx(-1.0)
-        assert offset[2] == pytest.approx(12.7, abs=0.01)  # 50 mils / 3.937
+        assert offset[2] == pytest.approx(12.7, abs=0.01)  # 50 mils × 0.254
 
 
 class TestObjXyCenter:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@
 
 from kicad_jlcimport.easyeda.ee_types import EEFootprint, EESymbol
 from kicad_jlcimport.easyeda.parser import (
-    MILS_TO_MM_DIVISOR,
+    MILS_TO_MM_MULTIPLIER,
     _find_svg_path,
     _parse_solid_region,
     _parse_svg_arc_path,
@@ -22,12 +22,23 @@ class TestMilToMm:
 
     def test_positive(self):
         result = mil_to_mm(100)
-        assert abs(result - 100 / MILS_TO_MM_DIVISOR) < 1e-10
+        assert abs(result - 100 * MILS_TO_MM_MULTIPLIER) < 1e-10
 
     def test_negative(self):
         result = mil_to_mm(-50)
         assert result < 0
-        assert abs(result - (-50 / MILS_TO_MM_DIVISOR)) < 1e-10
+        assert abs(result - (-50 * MILS_TO_MM_MULTIPLIER)) < 1e-10
+
+    def test_exact_grid_alignment(self):
+        # Issue #100: net-label connectivity in KiCad requires that imported pin
+        # endpoints land on integer-nm coordinates that match the schematic
+        # grid. EasyEDA pins on a 50-mil (5 unit) or 100-mil (10 unit) grid
+        # must convert to multiples of 1.27 mm (= 1,270,000 nm) exactly.
+        for ee in (10, 50, 100, 355, 500, 1000, 3995):
+            mm = mil_to_mm(ee)
+            nm = round(mm * 1_000_000)
+            # ee × 254,000 nm/unit must match the integer nm value exactly
+            assert nm == ee * 254_000, f"EE={ee} -> {mm} mm ({nm} nm), expected {ee * 254_000} nm"
 
 
 class TestParseSvgArcPath:


### PR DESCRIPTION
## Summary
- EasyEDA stores symbol coordinates in 10-mil units. Our `mil_to_mm` divided by the rounded constant `3.937` (≈ 1 / 0.254), pushing every imported pin endpoint **50–500 nm** off KiCad's internal nanometre grid.
- Wires snap to pins on click so manual wiring worked, but net labels — which land on the schematic grid — never matched the pin coordinates exactly and refused to auto-connect (issue #100).
- Replace `MILS_TO_MM_DIVISOR = 3.937` with `MILS_TO_MM_MULTIPLIER = 0.254` (exact) and route the two `model3d.py` offset sites through `mil_to_mm` so the conversion has a single source of truth.

### Quantified error (before → after)

| EE units | old `/3.937` (mm) | new `*0.254` (mm) | grid offset |
|---:|---|---|---:|
| 100  | 25.400051  | 25.4  | 51 nm |
| 355  | 90.170180  | 90.17 | 180 nm |
| 500  | 127.000254 | 127.0 | 254 nm |
| 1000 | 254.000508 | 254.0 | 508 nm |

After the fix, every EasyEDA-aligned pin lands on an exact integer-nanometre coordinate, and the `MILS_TO_MM_MULTIPLIER × 254000 nm/unit` invariant is asserted by a new regression test.

## Test plan
- [x] `ruff check .` and `ruff format --check .` clean
- [x] `pytest tests/ -q --cov=kicad_jlcimport --cov-fail-under=80` — 825 passed, 92% coverage
- [x] New `TestMilToMm.test_exact_grid_alignment` asserts integer-nm output for typical pin coordinates
- [x] Manual: import ATMEGA328P (C14877) via local PCM build, drop a net label on a pin — connects without a manual wire stub