### PR TITLE
Normalize KiCad geometry output grids

### DIFF
--- a/src/kicad_jlcimport/kicad/_format.py
+++ b/src/kicad_jlcimport/kicad/_format.py
@@ -3,10 +3,28 @@
 import math
 import uuid as _uuid_mod
 
+_GRID_SNAP_TOLERANCE_MM = 0.000125
+_SNAP_GRIDS_MM = (0.001, 0.00254)  # 1 um metric, 0.1 mil imperial
+
 
 def gen_uuid() -> str:
     """Generate a random UUID string for KiCad elements."""
     return str(_uuid_mod.uuid4())
+
+
+def _snap_grid_noise(v: float) -> float:
+    """Snap tiny EasyEDA conversion noise to common metric or imperial grids."""
+    snapped = v
+    best_delta = float("inf")
+    for grid in _SNAP_GRIDS_MM:
+        candidate = round(v / grid) * grid
+        delta = abs(v - candidate)
+        if delta < best_delta:
+            snapped = candidate
+            best_delta = delta
+    if best_delta <= _GRID_SNAP_TOLERANCE_MM:
+        return snapped
+    return v
 
 
 def fmt_float(v: float) -> str:
@@ -20,6 +38,13 @@ def fmt_float(v: float) -> str:
     if v == int(v) and abs(v) < 1e10:
         return str(int(v))
     return f"{v:.6f}".rstrip("0").rstrip(".")
+
+
+def fmt_geometry(v: float) -> str:
+    """Format a KiCad coordinate or dimension, snapping tiny grid noise."""
+    if math.isnan(v) or math.isinf(v):
+        return "0"
+    return fmt_float(_snap_grid_noise(v))
 
 
 def escape_sexpr(s: str) -> str:

--- a/src/kicad_jlcimport/kicad/footprint_writer.py
+++ b/src/kicad_jlcimport/kicad/footprint_writer.py
@@ -6,6 +6,7 @@ from ..easyeda.ee_types import EEFootprint
 from ..easyeda.parser import compute_arc_midpoint
 from ._format import escape_sexpr as _escape
 from ._format import fmt_float as _fmt
+from ._format import fmt_geometry as _geom
 from ._format import gen_uuid as _uuid
 from .version import DEFAULT_KICAD_VERSION, footprint_format_version, has_embedded_fonts, has_generator_version
 
@@ -53,10 +54,10 @@ def write_footprint(
         lines.append(f'  (tags "{_escape(keywords)}")')
 
     # Properties
-    lines.append(f'  (property "Reference" "REF**" (at 0 {_fmt(ref_y)} 0) (layer "F.SilkS") (uuid "{_uuid()}")')
+    lines.append(f'  (property "Reference" "REF**" (at 0 {_geom(ref_y)} 0) (layer "F.SilkS") (uuid "{_uuid()}")')
     lines.append("    (effects (font (size 1 1) (thickness 0.15)))")
     lines.append("  )")
-    lines.append(f'  (property "Value" "~" (at 0 {_fmt(val_y)} 0) (layer "F.Fab") (uuid "{_uuid()}")')
+    lines.append(f'  (property "Value" "~" (at 0 {_geom(val_y)} 0) (layer "F.Fab") (uuid "{_uuid()}")')
     lines.append("    (effects (font (size 1 1) (thickness 0.15)))")
     lines.append("  )")
     if datasheet:
@@ -82,8 +83,8 @@ def write_footprint(
             x1, y1 = track.points[i]
             x2, y2 = track.points[i + 1]
             lines.append(
-                f"  (fp_line (start {_fmt(x1)} {_fmt(y1)}) (end {_fmt(x2)} {_fmt(y2)})"
-                f" (stroke (width {_fmt(track.width)}) (type solid))"
+                f"  (fp_line (start {_geom(x1)} {_geom(y1)}) (end {_geom(x2)} {_geom(y2)})"
+                f" (stroke (width {_geom(track.width)}) (type solid))"
                 f' (layer "{track.layer}") (uuid "{_uuid()}"))'
             )
 
@@ -92,9 +93,9 @@ def write_footprint(
         end_x = circle.cx + circle.radius
         fill_str = " (fill solid)" if circle.filled else ""
         lines.append(
-            f"  (fp_circle (center {_fmt(circle.cx)} {_fmt(circle.cy)})"
-            f" (end {_fmt(end_x)} {_fmt(circle.cy)})"
-            f" (stroke (width {_fmt(circle.width)}) (type solid))"
+            f"  (fp_circle (center {_geom(circle.cx)} {_geom(circle.cy)})"
+            f" (end {_geom(end_x)} {_geom(circle.cy)})"
+            f" (stroke (width {_geom(circle.width)}) (type solid))"
             f"{fill_str}"
             f' (layer "{circle.layer}") (uuid "{_uuid()}"))'
         )
@@ -108,16 +109,16 @@ def write_footprint(
         else:
             s, e = arc.start, arc.end
         lines.append(
-            f"  (fp_arc (start {_fmt(s[0])} {_fmt(s[1])})"
-            f" (mid {_fmt(mid[0])} {_fmt(mid[1])})"
-            f" (end {_fmt(e[0])} {_fmt(e[1])})"
-            f" (stroke (width {_fmt(arc.width)}) (type solid))"
+            f"  (fp_arc (start {_geom(s[0])} {_geom(s[1])})"
+            f" (mid {_geom(mid[0])} {_geom(mid[1])})"
+            f" (end {_geom(e[0])} {_geom(e[1])})"
+            f" (stroke (width {_geom(arc.width)}) (type solid))"
             f' (layer "{arc.layer}") (uuid "{_uuid()}"))'
         )
 
     # Solid regions (e.g., pin 1 indicators, courtyard outlines)
     for region in footprint.regions:
-        pts_str = " ".join(f"(xy {_fmt(x)} {_fmt(y)})" for x, y in region.points)
+        pts_str = " ".join(f"(xy {_geom(x)} {_geom(y)})" for x, y in region.points)
         if region.layer in ("F.CrtYd", "B.CrtYd"):
             # Courtyard must be an unfilled outline, not a filled polygon
             lines.append(
@@ -137,21 +138,21 @@ def write_footprint(
     # Pads
     for pad in footprint.pads:
         pad_type, pad_shape, layers = _pad_type_info(pad)
-        at_str = f"(at {_fmt(pad.x)} {_fmt(pad.y)}"
+        at_str = f"(at {_geom(pad.x)} {_geom(pad.y)}"
         if pad.rotation != 0:
             at_str += f" {_fmt(pad.rotation)}"
         at_str += ")"
 
-        size_str = f"(size {_fmt(pad.width)} {_fmt(pad.height)})"
+        size_str = f"(size {_geom(pad.width)} {_geom(pad.height)})"
         layers_str = " ".join(f'"{layer}"' for layer in layers)
 
         if pad_shape == "custom" and pad.polygon_points:
             # Custom pad with polygon primitives.  The polygon vertices
             # already define the final shape, so omit pad rotation to
             # avoid double-rotating.
-            custom_at = f"(at {_fmt(pad.x)} {_fmt(pad.y)})"
+            custom_at = f"(at {_geom(pad.x)} {_geom(pad.y)})"
             pts = pad.polygon_points
-            pts_str = " ".join(f"(xy {_fmt(pts[i])} {_fmt(pts[i + 1])})" for i in range(0, len(pts) - 1, 2))
+            pts_str = " ".join(f"(xy {_geom(pts[i])} {_geom(pts[i + 1])})" for i in range(0, len(pts) - 1, 2))
             # Use a minimal anchor size — the actual shape is defined
             # entirely by the gr_poly primitive.  A large anchor would fill
             # in the castellated notches of the custom polygon.
@@ -174,9 +175,9 @@ def write_footprint(
     for hole in footprint.holes:
         diameter = hole.radius * 2
         lines.append(
-            f'  (pad "" np_thru_hole circle (at {_fmt(hole.x)} {_fmt(hole.y)})'
-            f" (size {_fmt(diameter)} {_fmt(diameter)})"
-            f" (drill {_fmt(diameter)})"
+            f'  (pad "" np_thru_hole circle (at {_geom(hole.x)} {_geom(hole.y)})'
+            f" (size {_geom(diameter)} {_geom(diameter)})"
+            f" (drill {_geom(diameter)})"
             f' (layers "*.Cu" "*.Mask") (uuid "{_uuid()}"))'
         )
 
@@ -185,7 +186,7 @@ def write_footprint(
         ox, oy, oz = model_offset
         rx, ry, rz = model_rotation
         lines.append(f'  (model "{model_path}"')
-        lines.append(f"    (offset (xyz {_fmt(ox)} {_fmt(oy)} {_fmt(oz)}))")
+        lines.append(f"    (offset (xyz {_geom(ox)} {_geom(oy)} {_geom(oz)}))")
         lines.append("    (scale (xyz 1 1 1))")
         lines.append(f"    (rotate (xyz {_fmt(rx)} {_fmt(ry)} {_fmt(rz)}))")
         lines.append("  )")
@@ -207,11 +208,11 @@ def _drill_str(pad) -> str:
     if pad.slot_length > 0:
         if pad.height >= pad.width:
             # Vertical slot: narrow dimension = drill, long dimension = slot_length
-            return f"(drill oval {_fmt(pad.drill)} {_fmt(pad.slot_length)})"
+            return f"(drill oval {_geom(pad.drill)} {_geom(pad.slot_length)})"
         else:
             # Horizontal slot: long dimension = slot_length, narrow dimension = drill
-            return f"(drill oval {_fmt(pad.slot_length)} {_fmt(pad.drill)})"
-    return f"(drill {_fmt(pad.drill)})"
+            return f"(drill oval {_geom(pad.slot_length)} {_geom(pad.drill)})"
+    return f"(drill {_geom(pad.drill)})"
 
 
 def _pad_type_info(pad):

--- a/src/kicad_jlcimport/kicad/symbol_writer.py
+++ b/src/kicad_jlcimport/kicad/symbol_writer.py
@@ -7,6 +7,7 @@ from ..easyeda.ee_types import EESymbol
 from ..easyeda.parser import compute_arc_midpoint
 from ._format import escape_sexpr as _escape
 from ._format import fmt_float as _fmt
+from ._format import fmt_geometry as _geom
 from .version import DEFAULT_KICAD_VERSION, has_generator_version, symbol_format_version
 
 
@@ -89,11 +90,11 @@ def write_symbol(
         ref_x = 0
         ref_y = _estimate_top(symbol) + 2.0
         hide_suffix = " hide" if hide_properties else ""
-        lines.append(f'    (property "Reference" "{prefix}" (at {_fmt(ref_x)} {_fmt(ref_y)} 0)')
+        lines.append(f'    (property "Reference" "{prefix}" (at {_geom(ref_x)} {_geom(ref_y)} 0)')
         lines.append(f"      (effects (font (size 1.27 1.27)){hide_suffix})")
         lines.append("    )")
         val_y = _estimate_bottom(symbol) - 2.0
-        lines.append(f'    (property "Value" "{name}" (at {_fmt(ref_x)} {_fmt(val_y)} 0)')
+        lines.append(f'    (property "Value" "{name}" (at {_geom(ref_x)} {_geom(val_y)} 0)')
         lines.append(f"      (effects (font (size 1.27 1.27)){hide_suffix})")
         lines.append("    )")
         if footprint_ref:
@@ -146,20 +147,20 @@ def write_symbol(
             lines.append("      (polyline")
             lines.append("        (pts")
             for px, py in pts:
-                lines.append(f"          (xy {_fmt(px)} {_fmt(py)})")
+                lines.append(f"          (xy {_geom(px)} {_geom(py)})")
             lines.append("        )")
             lines.append("        (stroke (width 0.254) (type solid))")
             lines.append("        (fill (type background))")
             lines.append("      )")
         else:
-            lines.append(f"      (rectangle (start {_fmt(rect.x)} {_fmt(rect.y)}) (end {_fmt(x2)} {_fmt(y2)})")
+            lines.append(f"      (rectangle (start {_geom(rect.x)} {_geom(rect.y)}) (end {_geom(x2)} {_geom(y2)})")
             lines.append("        (stroke (width 0.254) (type solid))")
             lines.append("        (fill (type background))")
             lines.append("      )")
 
     # Circles
     for circle in symbol.circles:
-        lines.append(f"      (circle (center {_fmt(circle.cx)} {_fmt(circle.cy)}) (radius {_fmt(circle.radius)})")
+        lines.append(f"      (circle (center {_geom(circle.cx)} {_geom(circle.cy)}) (radius {_geom(circle.radius)})")
         lines.append("        (stroke (width 0.254) (type solid))")
         # Use "outline" for filled circles (solid dark dot) vs "none" for hollow
         fill_type = "outline" if circle.filled else "none"
@@ -172,7 +173,7 @@ def write_symbol(
         # Close the path by adding first point to end if marked closed
         if poly.closed and len(points) >= 2 and points[0] != points[-1]:
             points.append(points[0])
-        pts_str = " ".join(f"(xy {_fmt(x)} {_fmt(y)})" for x, y in points)
+        pts_str = " ".join(f"(xy {_geom(x)} {_geom(y)})" for x, y in points)
         lines.append("      (polyline")
         lines.append(f"        (pts {pts_str})")
         lines.append("        (stroke (width 0.254) (type solid))")
@@ -188,9 +189,9 @@ def write_symbol(
         else:
             s, e = arc.start, arc.end
         lines.append(
-            f"      (arc (start {_fmt(s[0])} {_fmt(s[1])})"
-            f" (mid {_fmt(mid[0])} {_fmt(mid[1])})"
-            f" (end {_fmt(e[0])} {_fmt(e[1])})"
+            f"      (arc (start {_geom(s[0])} {_geom(s[1])})"
+            f" (mid {_geom(mid[0])} {_geom(mid[1])})"
+            f" (end {_geom(e[0])} {_geom(e[1])})"
         )
         lines.append("        (stroke (width 0.254) (type solid))")
         lines.append("        (fill (type none))")
@@ -198,16 +199,16 @@ def write_symbol(
 
     # Texts
     for text in symbol.texts:
-        lines.append(f'      (text "{_escape(text.text)}" (at {_fmt(text.x)} {_fmt(text.y)} {_fmt(text.rotation)})')
-        lines.append(f"        (effects (font (size {_fmt(text.font_size)} {_fmt(text.font_size)})))")
+        lines.append(f'      (text "{_escape(text.text)}" (at {_geom(text.x)} {_geom(text.y)} {_fmt(text.rotation)})')
+        lines.append(f"        (effects (font (size {_geom(text.font_size)} {_geom(text.font_size)})))")
         lines.append("      )")
 
     # Pins
     for pin in symbol.pins:
         elec_type = pin.electrical_type
         # Direction is encoded in the angle field of (at x y angle)
-        pin_line = f"      (pin {elec_type} line (at {_fmt(pin.x)} {_fmt(pin.y)} {_fmt(pin.rotation)})"
-        pin_line += f" (length {_fmt(pin.length)})"
+        pin_line = f"      (pin {elec_type} line (at {_geom(pin.x)} {_geom(pin.y)} {_fmt(pin.rotation)})"
+        pin_line += f" (length {_geom(pin.length)})"
         lines.append(pin_line)
 
         name_effects = "(effects (font (size 1.27 1.27)))"
@@ -224,7 +225,7 @@ def write_symbol(
     # Pin connection point dots (optional, for visual comparison)
     if include_pin_dots:
         for pin in symbol.pins:
-            lines.append(f"      (circle (center {_fmt(pin.x)} {_fmt(pin.y)}) (radius 0.254)")
+            lines.append(f"      (circle (center {_geom(pin.x)} {_geom(pin.y)}) (radius 0.254)")
             lines.append("        (stroke (width 0.127) (type solid))")
             lines.append("        (fill (type none))")
             lines.append("      )")

--- a/tests/test_kicad_format.py
+++ b/tests/test_kicad_format.py
@@ -1,6 +1,6 @@
 """Tests for _kicad_format.py - shared formatting utilities."""
 
-from kicad_jlcimport.kicad._format import escape_sexpr, fmt_float, gen_uuid
+from kicad_jlcimport.kicad._format import escape_sexpr, fmt_float, fmt_geometry, gen_uuid
 
 
 class TestGenUuid:
@@ -51,6 +51,9 @@ class TestFmtFloat:
         result = fmt_float(1.123456789)
         assert len(result.split(".")[1]) <= 6
 
+    def test_plain_float_does_not_snap_grid_noise(self):
+        assert fmt_float(2.800102) == "2.800102"
+
     def test_large_integer(self):
         assert fmt_float(1000.0) == "1000"
 
@@ -67,6 +70,28 @@ class TestFmtFloat:
 
     def test_negative_inf_returns_zero(self):
         assert fmt_float(float("-inf")) == "0"
+
+
+class TestFmtGeometry:
+    def test_snaps_easyeda_grid_noise(self):
+        # Issue #102: footprint coordinates/dimensions can carry tiny EasyEDA
+        # decimal residuals that make KiCad treat otherwise grid-aligned pads as
+        # off-grid.
+        assert fmt_geometry(2.800102) == "2.8"
+        assert fmt_geometry(0.240005) == "0.24"
+        assert fmt_geometry(-0.974981) == "-0.975"
+        assert fmt_geometry(0.000076) == "0"
+
+    def test_preserves_meaningful_sub_micron_values(self):
+        assert fmt_geometry(1.937512) == "1.937512"
+
+    def test_preserves_exact_imperial_values(self):
+        assert fmt_geometry(0.0254) == "0.0254"  # 1 mil
+        assert fmt_geometry(0.0508) == "0.0508"  # 2 mil
+        assert fmt_geometry(0.0762) == "0.0762"  # 3 mil
+
+    def test_nan_returns_zero(self):
+        assert fmt_geometry(float("nan")) == "0"
 
 
 class TestEscapeSexpr:


### PR DESCRIPTION
## Summary
- add geometry-specific KiCad numeric formatting that snaps tiny EasyEDA residuals to common metric or imperial grids
- apply geometry formatting to coordinates/dimensions while leaving generic float formatting and rotations unchanged
- cover issue-style residuals and exact mil values in formatter tests

## Testing
- PYTHONPATH=src ./.venv/bin/python -m ruff check .
- PYTHONPATH=src ./.venv/bin/python -m ruff format --check .
- PYTHONPATH=src ./.venv/bin/python -m pytest