### PR TITLE
Preserve EasyEDA pin styles

### DIFF
--- a/src/kicad_jlcimport/easyeda/ee_types.py
+++ b/src/kicad_jlcimport/easyeda/ee_types.py
@@ -91,6 +91,7 @@ class EEPin:
     rotation: float
     length: float
     electrical_type: str
+    style: str = "line"
     name_visible: bool = True
     number_visible: bool = True
 

--- a/src/kicad_jlcimport/easyeda/parser.py
+++ b/src/kicad_jlcimport/easyeda/parser.py
@@ -834,6 +834,16 @@ def _parse_pin(shape_str: str, origin_x: float, origin_y: float) -> EEPin:
     kicad_y = -mil_to_mm(y - origin_y)
 
     electrical_type = PIN_TYPES.get(elec_code, "unspecified")
+    has_dot = _pin_marker_visible(sections, 5)
+    has_clock = _pin_marker_visible(sections, 6)
+    if has_dot and has_clock:
+        pin_style = "inverted_clock"
+    elif has_dot:
+        pin_style = "inverted"
+    elif has_clock:
+        pin_style = "clock"
+    else:
+        pin_style = "line"
 
     return EEPin(
         number=number,
@@ -843,9 +853,19 @@ def _parse_pin(shape_str: str, origin_x: float, origin_y: float) -> EEPin:
         rotation=kicad_rotation,
         length=mil_to_mm(length),
         electrical_type=electrical_type,
+        style=pin_style,
         name_visible=name_visible,
         number_visible=number_visible,
     )
+
+
+def _pin_marker_visible(sections: list[str], index: int) -> bool:
+    if len(sections) <= index:
+        return False
+    parts = sections[index].split("~")
+    if not parts:
+        return False
+    return parts[0].strip().lower() in {"1", "show", "true"}
 
 
 def _parse_sym_rect(shape_str: str, origin_x: float, origin_y: float) -> EERectangle:

--- a/src/kicad_jlcimport/kicad/symbol_writer.py
+++ b/src/kicad_jlcimport/kicad/symbol_writer.py
@@ -206,8 +206,9 @@ def write_symbol(
     # Pins
     for pin in symbol.pins:
         elec_type = pin.electrical_type
+        style = pin.style
         # Direction is encoded in the angle field of (at x y angle)
-        pin_line = f"      (pin {elec_type} line (at {_geom(pin.x)} {_geom(pin.y)} {_fmt(pin.rotation)})"
+        pin_line = f"      (pin {elec_type} {style} (at {_geom(pin.x)} {_geom(pin.y)} {_fmt(pin.rotation)})"
         pin_line += f" (length {_geom(pin.length)})"
         lines.append(pin_line)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -327,6 +327,22 @@ class TestParseSymbolShapes:
         assert pin.number == "1"
         assert pin.electrical_type == "unspecified"
 
+    def test_parse_pin_styles(self):
+        def pin_style(dot_visible: str, clock_visible: str) -> str:
+            shape = (
+                "P~show~0~1~400~300~0~id1^^400~300^^M400,300h10~#880000"
+                "^^1~0~0~0~CLK~start~~~#0000FF^^1~0~0~0~1~end~~~#0000FF"
+                f"^^{dot_visible}~400~300^^{clock_visible}~M 397 297 L 400 300 L 397 303"
+            )
+            sym = parse_symbol_shapes([shape], 400, 300)
+            assert len(sym.pins) == 1
+            return sym.pins[0].style
+
+        assert pin_style("0", "0") == "line"
+        assert pin_style("1", "0") == "inverted"
+        assert pin_style("0", "1") == "clock"
+        assert pin_style("1", "1") == "inverted_clock"
+
     def test_parse_pin_horizontal_right(self):
         """Test horizontal pin extending right (h +N) -> KiCad 0°."""
         shape = "P~show~0~1~400~300~0~id1^^400~300^^M 400 300 h 10~#880000^^1~0~0~0~1~start~~#0000FF"

--- a/tests/test_symbol_writer.py
+++ b/tests/test_symbol_writer.py
@@ -131,6 +131,22 @@ class TestWriteSymbol:
         assert '(name "VCC"' in result
         assert '(number "1"' in result
 
+    def test_pin_style_generation(self):
+        for style in ("inverted", "clock", "inverted_clock"):
+            pin = EEPin(
+                number="1",
+                name="CLK",
+                x=0,
+                y=0,
+                rotation=0,
+                length=2.54,
+                electrical_type="input",
+                style=style,
+            )
+            sym = _make_symbol(pins=[pin])
+            result = write_symbol(sym, "Test")
+            assert f"(pin input {style}" in result
+
     def test_pin_hidden_name(self):
         pin = EEPin(
             number="1", name="VCC", x=0, y=0, rotation=0, length=2.54, electrical_type="power_in", name_visible=False


### PR DESCRIPTION
## Summary

- parse visible EasyEDA pin dot and clock markers into KiCad pin styles
- emit `inverted`, `clock`, and `inverted_clock` pin styles when present
- keep existing pins as `line` by default

## Tests

- `.venv/bin/pytest tests/test_parser.py tests/test_symbol_writer.py -q`
- `.venv/bin/ruff check src/kicad_jlcimport/easyeda/ee_types.py src/kicad_jlcimport/easyeda/parser.py src/kicad_jlcimport/kicad/symbol_writer.py tests/test_parser.py tests/test_symbol_writer.py`
