### PR TITLE
Use catalog datasheets for direct CLI imports instead of EasyEDA footprint links

### DIFF
--- a/src/kicad_jlcimport/cli.py
+++ b/src/kicad_jlcimport/cli.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """CLI tool for testing JLCImport search and import."""
 
+from __future__ import annotations
+
 import argparse
 import os
 import sys
@@ -101,6 +103,30 @@ def _resolve_project_dir(path: str) -> str:
     return abs_path
 
 
+def _find_exact_search_result(lcsc_id: str) -> dict | None:
+    """Return catalog metadata for *lcsc_id* when search has an exact match."""
+    best_match = None
+    for search_fn in (search_components, search_components_cn):
+        try:
+            result = search_fn(lcsc_id, page_size=10)
+        except APIError:
+            continue
+        for item in result.get("results", []):
+            if str(item.get("lcsc", "")).upper() != lcsc_id:
+                continue
+            if item.get("datasheet"):
+                return item
+            if best_match is None:
+                best_match = item
+    return best_match
+
+
+def _catalog_metadata_for_import(args, lcsc_id: str) -> dict | None:
+    if not getattr(args, "catalog_metadata", False):
+        return None
+    return _find_exact_search_result(lcsc_id)
+
+
 def cmd_import(args):
     """Import a component and show/save the output."""
     try:
@@ -121,6 +147,7 @@ def cmd_import(args):
             if not os.path.isdir(lib_dir):
                 print(f"  Error: project path does not exist or is not a directory: {args.project}")
                 return
+            search_result = _catalog_metadata_for_import(args, lcsc_id)
             result = import_component(
                 lcsc_id,
                 lib_dir,
@@ -129,6 +156,7 @@ def cmd_import(args):
                 use_global=False,
                 log=log,
                 kicad_version=kicad_version,
+                search_result=search_result,
             )
         elif getattr(args, "global_dest", False) or getattr(args, "global_lib_dir", None):
             if getattr(args, "global_lib_dir", None):
@@ -138,6 +166,7 @@ def cmd_import(args):
                     return
             else:
                 lib_dir = get_global_lib_dir(kicad_version)
+            search_result = _catalog_metadata_for_import(args, lcsc_id)
             result = import_component(
                 lcsc_id,
                 lib_dir,
@@ -146,8 +175,10 @@ def cmd_import(args):
                 use_global=True,
                 log=log,
                 kicad_version=kicad_version,
+                search_result=search_result,
             )
         elif args.output:
+            search_result = _catalog_metadata_for_import(args, lcsc_id)
             result = import_component(
                 lcsc_id,
                 args.output,
@@ -155,11 +186,13 @@ def cmd_import(args):
                 export_only=True,
                 log=log,
                 kicad_version=kicad_version,
+                search_result=search_result,
             )
         else:
             # No destination: fetch, parse, and show summary without writing
             import tempfile
 
+            search_result = _catalog_metadata_for_import(args, lcsc_id)
             with tempfile.TemporaryDirectory() as tmp_dir:
                 result = import_component(
                     lcsc_id,
@@ -168,6 +201,7 @@ def cmd_import(args):
                     export_only=True,
                     log=log,
                     kicad_version=kicad_version,
+                    search_result=search_result,
                 )
             if not args.show:
                 fp_content = result["fp_content"]
@@ -278,7 +312,7 @@ examples:
         default=DEFAULT_KICAD_VERSION,
         help=f"Target KiCad version (default: {DEFAULT_KICAD_VERSION})",
     )
-    ip.set_defaults(func=cmd_import)
+    ip.set_defaults(func=cmd_import, catalog_metadata=True)
 
     args = parser.parse_args()
     if args.insecure:

--- a/src/kicad_jlcimport/easyeda/api.py
+++ b/src/kicad_jlcimport/easyeda/api.py
@@ -13,6 +13,7 @@ import sys
 import urllib.request
 import warnings
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -771,6 +772,29 @@ def _strip_cjk_parens(text: str) -> str:
     return re.sub(r"\([^\x00-\x7F]+\)", "", text).strip()
 
 
+def _looks_like_datasheet_url(url: str) -> bool:
+    """Return True when *url* appears to point to a datasheet, not a product page."""
+    try:
+        path = urlparse(url).path.lower()
+    except ValueError:
+        return False
+    return path.endswith(".pdf") or "datasheet" in path
+
+
+def _normalize_datasheet_url(url: str) -> str:
+    """Normalize an EasyEDA datasheet link, returning empty for non-datasheet URLs."""
+    url = (url or "").strip()
+    if not url:
+        return ""
+    if url.startswith("//"):
+        url = "https:" + url
+    elif not url.startswith(("http://", "https://")):
+        return ""
+    if not _looks_like_datasheet_url(url):
+        return ""
+    return url
+
+
 def fetch_full_component(lcsc_id: str) -> Dict[str, Any]:
     """High-level: fetch all data needed for a component.
 
@@ -811,9 +835,11 @@ def fetch_full_component(lcsc_id: str) -> Dict[str, Any]:
     if prefix.endswith("?"):
         prefix = prefix[:-1]
 
-    datasheet = c_para.get("link", fp_c_para.get("link", ""))
-    if datasheet and not datasheet.startswith("http"):
-        datasheet = "https:" + datasheet if datasheet.startswith("//") else ""
+    datasheet = _normalize_datasheet_url(c_para.get("link", ""))
+    if not datasheet:
+        # Footprint records are commonly shared between parts; their link may
+        # point to whichever product originally contributed the footprint.
+        datasheet = _normalize_datasheet_url(fp_c_para.get("link", ""))
 
     # 3D model UUID from footprint head
     uuid_3d = fp_data.get("dataStr", {}).get("head", {}).get("uuid_3d", "")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1053,3 +1053,50 @@ class TestFetchFullComponent:
             with mock.patch.object(api, "fetch_component_data", side_effect=[fp_data, sym_data]):
                 result = api.fetch_full_component("C1")
                 assert result["datasheet"] == ""
+
+    def test_ignores_plain_footprint_product_page_link(self):
+        uuids = [{"component_uuid": "sym1"}, {"component_uuid": "fp1"}]
+        sym_data = {
+            "title": "TPS563201DDCR",
+            "dataStr": {
+                "head": {
+                    "c_para": {
+                        "pre": "U?",
+                        "Supplier Part": "C116592",
+                        "Manufacturer Part": "TPS563201DDCR",
+                    }
+                }
+            },
+        }
+        fp_data = {
+            "dataStr": {
+                "head": {
+                    "c_para": {
+                        "pre": "U?",
+                        "link": "https://item.szlcsc.com/169042.html",
+                    }
+                }
+            }
+        }
+        with mock.patch.object(api, "fetch_component_uuids", return_value=uuids):
+            with mock.patch.object(api, "fetch_component_data", side_effect=[fp_data, sym_data]):
+                result = api.fetch_full_component("C116592")
+                assert result["datasheet"] == ""
+
+    def test_uses_datasheet_like_footprint_link(self):
+        uuids = [{"component_uuid": "sym1"}, {"component_uuid": "fp1"}]
+        sym_data = {"dataStr": {"head": {"c_para": {"pre": "U?"}}}}
+        fp_data = {
+            "dataStr": {
+                "head": {
+                    "c_para": {
+                        "pre": "U?",
+                        "link": "https://item.szlcsc.com/datasheet/TPS563201DDCR/117846.html",
+                    }
+                }
+            }
+        }
+        with mock.patch.object(api, "fetch_component_uuids", return_value=uuids):
+            with mock.patch.object(api, "fetch_component_data", side_effect=[fp_data, sym_data]):
+                result = api.fetch_full_component("C116592")
+                assert result["datasheet"] == "https://item.szlcsc.com/datasheet/TPS563201DDCR/117846.html"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,72 @@
 from types import SimpleNamespace
 
 
+def test_find_exact_search_result_prefers_datasheet_match(monkeypatch):
+    import kicad_jlcimport.cli as cli
+
+    def fake_global_search(keyword, page_size=10):
+        assert keyword == "C116592"
+        assert page_size == 10
+        return {
+            "results": [
+                {"lcsc": "C999999", "datasheet": "https://example.invalid/wrong.pdf"},
+                {"lcsc": "C116592", "datasheet": ""},
+            ]
+        }
+
+    def fake_cn_search(keyword, page_size=10):
+        assert keyword == "C116592"
+        assert page_size == 10
+        return {"results": [{"lcsc": "C116592", "datasheet": "https://example.invalid/correct.pdf"}]}
+
+    monkeypatch.setattr(cli, "search_components", fake_global_search)
+    monkeypatch.setattr(cli, "search_components_cn", fake_cn_search)
+
+    result = cli._find_exact_search_result("C116592")
+
+    assert result["lcsc"] == "C116592"
+    assert result["datasheet"] == "https://example.invalid/correct.pdf"
+
+
+def test_cli_import_passes_exact_catalog_metadata(tmp_path, monkeypatch):
+    import kicad_jlcimport.cli as cli
+
+    exact_result = {
+        "lcsc": "C116592",
+        "brand": "Texas Instruments",
+        "description": "Buck converter",
+        "datasheet": "https://example.invalid/tps563201.pdf",
+    }
+    captured = {}
+
+    def fake_import_component(lcsc_id, lib_dir, lib_name, **kwargs):
+        captured["lcsc_id"] = lcsc_id
+        captured["lib_dir"] = lib_dir
+        captured["lib_name"] = lib_name
+        captured.update(kwargs)
+        return {"title": "TPS563201DDCR", "name": "TPS563201DDCR", "fp_content": "fp\n", "sym_content": ""}
+
+    monkeypatch.setattr(cli, "_find_exact_search_result", lambda lcsc_id: exact_result)
+    monkeypatch.setattr(cli, "import_component", fake_import_component)
+
+    args = SimpleNamespace(
+        part="C116592",
+        show=None,
+        output=str(tmp_path),
+        project=None,
+        global_dest=False,
+        global_lib_dir=None,
+        overwrite=False,
+        lib_name="MyLib",
+        kicad_version=10,
+        catalog_metadata=True,
+    )
+    cli.cmd_import(args)
+
+    assert captured["lcsc_id"] == "C116592"
+    assert captured["search_result"] is exact_result
+
+
 def test_cli_import_project_writes_kicad_library(tmp_path, monkeypatch, capsys):
     import kicad_jlcimport.cli as cli
     import kicad_jlcimport.importer as importer


### PR DESCRIPTION
Direct CLI imports previously used EasyEDA component metadata only. For some parts, EasyEDA reuses footprint records whose link field points to the product page of the footprint’s original contributor, not the requested LCSC part, which caused wrong Datasheet properties. I noticed this when i imported part C116592 and noticed it had an incorrect datasheet (https://item.szlcsc.com/169042.html).

This change makes direct imports look up exact catalog metadata and prefer its datasheet URL, matching the GUI/TUI import path. It also rejects plain product-page footprint links as datasheets while still allowing real PDF/datasheet URLs as fallback.